### PR TITLE
Link year and country parameters to `build_reference_statistics` rule

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -80,6 +80,8 @@ rule build_reference_statistics:
         "logs/build_reference_statistics.log",
     params:
         datasets=config["datasets"],
+        year=config["network_validation"]["year"],
+        countries=config["network_validation"]["countries"],
     script:
         "scripts/build_reference_statistics.py"
 

--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -22,6 +22,8 @@ SPDX-License-Identifier: CC-BY-4.0
 
 ### Minor Changes and bug-fixing
 
+* [Link year and country parameters to `build_reference_statistics` rule PR #58](https://github.com/pypsa-meets-earth/pypsa-earth-status/pull/58)
+
 * [Add Read the Docs badge to README.md PR #35](https://github.com/pypsa-meets-earth/pypsa-earth-status/pull/35)
 
 * [Handle empty networks and make validation plots robust to missing data PR #34](https://github.com/pypsa-meets-earth/pypsa-earth-status/pull/34)

--- a/scripts/build_reference_statistics.py
+++ b/scripts/build_reference_statistics.py
@@ -28,15 +28,10 @@ def filter_data_by_config(df, column, valid_values):
     return df[df[column].isin(valid_values)]
 
 
-def process_reference_statistics(inputs, outputs, config):
+def process_reference_statistics(inputs, outputs, year, countries):
     """
     Processes demand and installed capacity data based on the specified year and countries.
     """
-    year = config["network_validation"]["year"][0]  # Extracting the year from config
-    countries = config["network_validation"][
-        "countries"
-    ]  # Extracting the list of countries
-
     # Process demand data
     df_demand = read_csv_nafix(inputs["demand_owid"])
     df_demand = filter_data_by_config(df_demand, "region", countries)
@@ -68,4 +63,7 @@ if __name__ == "__main__":
 
     configure_logging(snakemake)
 
-    process_reference_statistics(snakemake.input, snakemake.output, snakemake.config)
+    year = snakemake.params["year"][0]
+    countries = snakemake.params["countries"]
+
+    process_reference_statistics(snakemake.input, snakemake.output, year, countries)


### PR DESCRIPTION
# Closes # (if applicable).

## Changes proposed in this Pull Request
Good day. This PR adds params to `build_reference_statistics` rule, so that snakemake tracks when country or year is changed.

## Checklist

- [ ] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [ ] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented, including updates to docstrings for meaningful functions.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in all of `config.yaml`.
- [ ] A note for the release notes `doc/release-notes.md` is amended in the format of previous release notes, including reference to the requested PR.
