### PR TITLE
Store validation outputs per configuration

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 import sys
+from pathlib import Path
 
 sys.path.append("./scripts")
 
@@ -13,6 +14,28 @@ from helpers import create_country_list
 
 
 configfile: "config.yaml"
+
+validation_config = config["network_validation"]
+
+network_path = validation_config["network_path"]
+countries = validation_config["countries"]
+years = validation_config["year"]
+
+country_tag = "-".join(sorted(countries))
+year_tag = "-".join(str(year) for year in sorted(years))
+network_tag = Path(network_path).stem
+
+validation_id = f"{country_tag}_{year_tag}_{network_tag}"
+
+
+reference_statistics_dir = (
+    f"resources/reference_statistics/{validation_id}"
+)
+network_statistics_dir = (
+    f"resources/network_statistics/{validation_id}"
+)
+results_dir = f"results/{validation_id}"
+logs_dir = f"logs/{validation_id}"
 
 
 rule clean:
@@ -48,21 +71,33 @@ rule build_reference_installed_capacity_irena:
 rule build_network_geojson:
     input:
         buscodes="data/electricity_transmission/Input - Center points.csv",
-        lineexist="data/electricity_transmission/GTD-v1.1_regional_existing.csv",
-        lineplan="data/electricity_transmission/GTD-v1.1_regional_planned.csv",
-        network_path=config["network_validation"]["network_path"],
-    output:
-        network_existing="resources/reference_statistics/network_exist.geojson",
-        network_planned="resources/reference_statistics/network_planned.geojson",
-        network_model="resources/network_statistics/network_model.geojson",
-    log:
-        "logs/build_network_geojson.log",
-    params:
-        countries=config["network_validation"]["countries"],
-        shapefile=config["network_validation"].get("shapefile", False),
-        validate_cross_border_capacity=config["network_validation"].get(
-            "validate_cross_border_capacity", True
+        lineexist=(
+            "data/electricity_transmission/"
+            "GTD-v1.1_regional_existing.csv"
         ),
+        lineplan=(
+            "data/electricity_transmission/"
+            "GTD-v1.1_regional_planned.csv"
+        ),
+        network_path=network_path,
+    output:
+        network_existing=(
+            f"{reference_statistics_dir}/network_exist.geojson"
+        ),
+        network_planned=(
+            f"{reference_statistics_dir}/network_planned.geojson"
+        ),
+        network_model=(
+            f"{network_statistics_dir}/network_model.geojson"
+        ),
+    log:
+        f"{logs_dir}/build_network_geojson.log",
+    params:
+        countries=countries,
+        shapefile=validation_config["shapefile"],
+        validate_cross_border_capacity=validation_config[
+            "validate_cross_border_capacity"
+        ],
     script:
         "scripts/build_network_geojson.py"
 
@@ -71,91 +106,132 @@ rule build_reference_statistics:
     input:
         demand_owid="resources/clean/owid_demand_data.csv",
         cap_irena="resources/clean/irena_capacity_data.csv",
-        # other sources
     output:
-        demand="resources/reference_statistics/demand.csv",
-        installed_capacity="resources/reference_statistics/installed_capacity.csv",
-        # energy_dispatch="resources/reference_statistics/energy_dispatch.geojson"
+        demand=f"{reference_statistics_dir}/demand.csv",
+        installed_capacity=(
+            f"{reference_statistics_dir}/installed_capacity.csv"
+        ),
     log:
-        "logs/build_reference_statistics.log",
+        f"{logs_dir}/build_reference_statistics.log",
     params:
         datasets=config["datasets"],
-        year=config["network_validation"]["year"],
-        countries=config["network_validation"]["countries"],
+        year=years,
+        countries=countries,
     script:
         "scripts/build_reference_statistics.py"
 
 
 rule build_network_statistics:
     input:
-        network_path=config["network_validation"]["network_path"],
-        # other sources
+        network_path=network_path,
     output:
-        demand="resources/network_statistics/demand.csv",
-        installed_capacity="resources/network_statistics/installed_capacity.csv",
-        optimal_capacity="resources/network_statistics/optimal_capacity.csv",
-        # energy_dispatch="resources/network_statistics/energy_dispatch.csv",
-        # network="resources/network_statistics/network.geojson",
+        demand=f"{network_statistics_dir}/demand.csv",
+        installed_capacity=(
+            f"{network_statistics_dir}/installed_capacity.csv"
+        ),
+        optimal_capacity=(
+            f"{network_statistics_dir}/optimal_capacity.csv"
+        ),
     log:
-        "logs/build_network_statistics.log",
+        f"{logs_dir}/build_network_statistics.log",
     params:
-        network=config["network_validation"],
+        network_path=network_path,
+        year=years,
+        countries=countries,
+        shapefile=validation_config["shapefile"],
+        validate_cross_border_capacity=validation_config[
+            "validate_cross_border_capacity"
+        ],
+        network=validation_config,
     script:
         "scripts/build_network_statistics.py"
 
 
 rule make_comparison:
     input:
-        demand_network="resources/network_statistics/demand.csv",
-        installed_capacity_network="resources/network_statistics/installed_capacity.csv",
-        optimal_capacity_network="resources/network_statistics/optimal_capacity.csv",
-        # energy_dispatch_network="resources/network_statistics/energy_dispatch.csv",
-        # network_network="resources/network_statistics/network.geojson",
-        network_geojson_network="resources/network_statistics/network_model.geojson",
-        demand_reference="resources/reference_statistics/demand.csv",
-        installed_capacity_reference="resources/reference_statistics/installed_capacity.csv",
-        # energy_dispatch_reference="resources/reference_statistics/energy_dispatch.geojson"
-        network_geojson_reference="resources/reference_statistics/network_exist.geojson",
+        demand_network=f"{network_statistics_dir}/demand.csv",
+        installed_capacity_network=(
+            f"{network_statistics_dir}/installed_capacity.csv"
+        ),
+        optimal_capacity_network=(
+            f"{network_statistics_dir}/optimal_capacity.csv"
+        ),
+        network_geojson_network=(
+            f"{network_statistics_dir}/network_model.geojson"
+        ),
+        demand_reference=f"{reference_statistics_dir}/demand.csv",
+        installed_capacity_reference=(
+            f"{reference_statistics_dir}/installed_capacity.csv"
+        ),
+        network_geojson_reference=(
+            f"{reference_statistics_dir}/network_exist.geojson"
+        ),
     output:
-        demand_comparison="results/tables/demand.csv",
-        installed_capacity_comparison="results/tables/installed_capacity.csv",
-        optimal_capacity_comparison="results/tables/optimal_capacity.csv",
-        network_comparison_geojson="results/network_comparison.geojson",
-        # energy_dispatch_comparison="results/tables/energy_dispatch.geojson"
-        # network_comparison="results/tables/network.geojson"
+        demand_comparison=f"{results_dir}/tables/demand.csv",
+        installed_capacity_comparison=(
+            f"{results_dir}/tables/installed_capacity.csv"
+        ),
+        optimal_capacity_comparison=(
+            f"{results_dir}/tables/optimal_capacity.csv"
+        ),
+        network_comparison_geojson=(
+            f"{results_dir}/network_comparison.geojson"
+        ),
     log:
-        "logs/make_comparison.log",
+        f"{logs_dir}/make_comparison.log",
     script:
         "scripts/make_comparison.py"
 
 
 rule visualize_data:
     input:
-        demand_comparison="results/tables/demand.csv",
-        installed_capacity_comparison="results/tables/installed_capacity.csv",
-        optimal_capacity_comparison="results/tables/optimal_capacity.csv",
+        demand_comparison=f"{results_dir}/tables/demand.csv",
+        installed_capacity_comparison=(
+            f"{results_dir}/tables/installed_capacity.csv"
+        ),
+        optimal_capacity_comparison=(
+            f"{results_dir}/tables/optimal_capacity.csv"
+        ),
         osm_lines=os.path.join(
-            config["plot_osm_grid_network"]["grid_path"], "all_clean_lines.geojson"
+            config["plot_osm_grid_network"]["grid_path"],
+            "all_clean_lines.geojson",
         ),
         osm_substations=os.path.join(
             config["plot_osm_grid_network"]["grid_path"],
             "all_clean_substations.geojson",
         ),
-        # energy_dispatch_comparison="results/tables/energy_dispatch.geojson"
-        # network_comparison="results/tables/network.geojson"
     output:
-        plot_demand="results/figures/demand_comparison.png",
-        plot_installed_capacity="results/figures/installed_capacity_comparison.png",
-        plot_capacity_mix="results/figures/capacity_mix_comparison.png",
-        plot_capacity_grid="results/figures/capacity_grid_comparison.png",
-        plot_grid_network="results/figures/grid_network.png",
-        line_length_by_voltage="results/tables/line_length_by_voltage.csv",
+        plot_demand=(
+            f"{results_dir}/figures/demand_comparison.png"
+        ),
+        plot_installed_capacity=(
+            f"{results_dir}/figures/"
+            "installed_capacity_comparison.png"
+        ),
+        plot_capacity_mix=(
+            f"{results_dir}/figures/capacity_mix_comparison.png"
+        ),
+        plot_capacity_grid=(
+            f"{results_dir}/figures/capacity_grid_comparison.png"
+        ),
+        plot_grid_network=(
+            f"{results_dir}/figures/grid_network.png"
+        ),
+        line_length_by_voltage=(
+            f"{results_dir}/tables/line_length_by_voltage.csv"
+        ),
     log:
-        "logs/visualize_data.log",
+        f"{logs_dir}/visualize_data.log",
     params:
-        line_voltages=config["plot_osm_grid_network"]["line_voltages"],
-        voltage_colors=config["plot_osm_grid_network"]["voltage_colors"],
-        plot_circuits=config["plot_osm_grid_network"]["plot_circuits"],
+        line_voltages=config[
+            "plot_osm_grid_network"
+        ]["line_voltages"],
+        voltage_colors=config[
+            "plot_osm_grid_network"
+        ]["voltage_colors"],
+        plot_circuits=config[
+            "plot_osm_grid_network"
+        ]["plot_circuits"],
     script:
         "scripts/visualize_data.py"
 

--- a/Snakefile
+++ b/Snakefile
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 import sys
-from pathlib import Path
 
 sys.path.append("./scripts")
 
@@ -22,11 +21,7 @@ network_path = validation_config["network_path"]
 countries = validation_config["countries"]
 years = validation_config["year"]
 
-country_tag = "-".join(sorted(countries))
-year_tag = "-".join(str(year) for year in sorted(years))
-network_tag = Path(network_path).stem
-
-validation_id = f"{country_tag}_{year_tag}_{network_tag}"
+validation_id = validation_config["name"]
 
 
 reference_statistics_dir = f"resources/reference_statistics/{validation_id}"

--- a/Snakefile
+++ b/Snakefile
@@ -73,9 +73,9 @@ rule build_network_geojson:
         lineplan="data/electricity_transmission/GTD-v1.1_regional_planned.csv",
         network_path=network_path,
     output:
-        network_existing=(f"{reference_statistics_dir}/network_exist.geojson"),
-        network_planned=(f"{reference_statistics_dir}/network_planned.geojson"),
-        network_model=(f"{network_statistics_dir}/network_model.geojson"),
+        network_existing=f"{reference_statistics_dir}/network_exist.geojson",
+        network_planned=f"{reference_statistics_dir}/network_planned.geojson",
+        network_model=f"{network_statistics_dir}/network_model.geojson",
     log:
         f"{logs_dir}/build_network_geojson.log",
     params:
@@ -94,7 +94,7 @@ rule build_reference_statistics:
         cap_irena="resources/clean/irena_capacity_data.csv",
     output:
         demand=f"{reference_statistics_dir}/demand.csv",
-        installed_capacity=(f"{reference_statistics_dir}/installed_capacity.csv"),
+        installed_capacity=f"{reference_statistics_dir}/installed_capacity.csv",
     log:
         f"{logs_dir}/build_reference_statistics.log",
     params:
@@ -110,8 +110,8 @@ rule build_network_statistics:
         network_path=network_path,
     output:
         demand=f"{network_statistics_dir}/demand.csv",
-        installed_capacity=(f"{network_statistics_dir}/installed_capacity.csv"),
-        optimal_capacity=(f"{network_statistics_dir}/optimal_capacity.csv"),
+        installed_capacity=f"{network_statistics_dir}/installed_capacity.csv",
+        optimal_capacity=f"{network_statistics_dir}/optimal_capacity.csv",
     log:
         f"{logs_dir}/build_network_statistics.log",
     params:
@@ -130,19 +130,19 @@ rule build_network_statistics:
 rule make_comparison:
     input:
         demand_network=f"{network_statistics_dir}/demand.csv",
-        installed_capacity_network=(f"{network_statistics_dir}/installed_capacity.csv"),
-        optimal_capacity_network=(f"{network_statistics_dir}/optimal_capacity.csv"),
-        network_geojson_network=(f"{network_statistics_dir}/network_model.geojson"),
+        installed_capacity_network=f"{network_statistics_dir}/installed_capacity.csv",
+        optimal_capacity_network=f"{network_statistics_dir}/optimal_capacity.csv",
+        network_geojson_network=f"{network_statistics_dir}/network_model.geojson",
         demand_reference=f"{reference_statistics_dir}/demand.csv",
         installed_capacity_reference=(
             f"{reference_statistics_dir}/installed_capacity.csv"
         ),
-        network_geojson_reference=(f"{reference_statistics_dir}/network_exist.geojson"),
+        network_geojson_reference=f"{reference_statistics_dir}/network_exist.geojson",
     output:
         demand_comparison=f"{results_dir}/tables/demand.csv",
-        installed_capacity_comparison=(f"{results_dir}/tables/installed_capacity.csv"),
-        optimal_capacity_comparison=(f"{results_dir}/tables/optimal_capacity.csv"),
-        network_comparison_geojson=(f"{results_dir}/network_comparison.geojson"),
+        installed_capacity_comparison=f"{results_dir}/tables/installed_capacity.csv",
+        optimal_capacity_comparison=f"{results_dir}/tables/optimal_capacity.csv",
+        network_comparison_geojson=f"{results_dir}/network_comparison.geojson",
     log:
         f"{logs_dir}/make_comparison.log",
     script:
@@ -152,8 +152,8 @@ rule make_comparison:
 rule visualize_data:
     input:
         demand_comparison=f"{results_dir}/tables/demand.csv",
-        installed_capacity_comparison=(f"{results_dir}/tables/installed_capacity.csv"),
-        optimal_capacity_comparison=(f"{results_dir}/tables/optimal_capacity.csv"),
+        installed_capacity_comparison=f"{results_dir}/tables/installed_capacity.csv",
+        optimal_capacity_comparison=f"{results_dir}/tables/optimal_capacity.csv",
         osm_lines=os.path.join(
             config["plot_osm_grid_network"]["grid_path"],
             "all_clean_lines.geojson",
@@ -163,14 +163,14 @@ rule visualize_data:
             "all_clean_substations.geojson",
         ),
     output:
-        plot_demand=(f"{results_dir}/figures/demand_comparison.png"),
+        plot_demand=f"{results_dir}/figures/demand_comparison.png",
         plot_installed_capacity=(
             f"{results_dir}/figures/" "installed_capacity_comparison.png"
         ),
-        plot_capacity_mix=(f"{results_dir}/figures/capacity_mix_comparison.png"),
-        plot_capacity_grid=(f"{results_dir}/figures/capacity_grid_comparison.png"),
-        plot_grid_network=(f"{results_dir}/figures/grid_network.png"),
-        line_length_by_voltage=(f"{results_dir}/tables/line_length_by_voltage.csv"),
+        plot_capacity_mix=f"{results_dir}/figures/capacity_mix_comparison.png",
+        plot_capacity_grid=f"{results_dir}/figures/capacity_grid_comparison.png",
+        plot_grid_network=f"{results_dir}/figures/grid_network.png",
+        line_length_by_voltage=f"{results_dir}/tables/line_length_by_voltage.csv",
     log:
         f"{logs_dir}/visualize_data.log",
     params:

--- a/Snakefile
+++ b/Snakefile
@@ -15,6 +15,7 @@ from helpers import create_country_list
 
 configfile: "config.yaml"
 
+
 validation_config = config["network_validation"]
 
 network_path = validation_config["network_path"]
@@ -28,12 +29,8 @@ network_tag = Path(network_path).stem
 validation_id = f"{country_tag}_{year_tag}_{network_tag}"
 
 
-reference_statistics_dir = (
-    f"resources/reference_statistics/{validation_id}"
-)
-network_statistics_dir = (
-    f"resources/network_statistics/{validation_id}"
-)
+reference_statistics_dir = f"resources/reference_statistics/{validation_id}"
+network_statistics_dir = f"resources/network_statistics/{validation_id}"
 results_dir = f"results/{validation_id}"
 logs_dir = f"logs/{validation_id}"
 
@@ -71,25 +68,13 @@ rule build_reference_installed_capacity_irena:
 rule build_network_geojson:
     input:
         buscodes="data/electricity_transmission/Input - Center points.csv",
-        lineexist=(
-            "data/electricity_transmission/"
-            "GTD-v1.1_regional_existing.csv"
-        ),
-        lineplan=(
-            "data/electricity_transmission/"
-            "GTD-v1.1_regional_planned.csv"
-        ),
+        lineexist=("data/electricity_transmission/" "GTD-v1.1_regional_existing.csv"),
+        lineplan=("data/electricity_transmission/" "GTD-v1.1_regional_planned.csv"),
         network_path=network_path,
     output:
-        network_existing=(
-            f"{reference_statistics_dir}/network_exist.geojson"
-        ),
-        network_planned=(
-            f"{reference_statistics_dir}/network_planned.geojson"
-        ),
-        network_model=(
-            f"{network_statistics_dir}/network_model.geojson"
-        ),
+        network_existing=(f"{reference_statistics_dir}/network_exist.geojson"),
+        network_planned=(f"{reference_statistics_dir}/network_planned.geojson"),
+        network_model=(f"{network_statistics_dir}/network_model.geojson"),
     log:
         f"{logs_dir}/build_network_geojson.log",
     params:
@@ -108,9 +93,7 @@ rule build_reference_statistics:
         cap_irena="resources/clean/irena_capacity_data.csv",
     output:
         demand=f"{reference_statistics_dir}/demand.csv",
-        installed_capacity=(
-            f"{reference_statistics_dir}/installed_capacity.csv"
-        ),
+        installed_capacity=(f"{reference_statistics_dir}/installed_capacity.csv"),
     log:
         f"{logs_dir}/build_reference_statistics.log",
     params:
@@ -126,12 +109,8 @@ rule build_network_statistics:
         network_path=network_path,
     output:
         demand=f"{network_statistics_dir}/demand.csv",
-        installed_capacity=(
-            f"{network_statistics_dir}/installed_capacity.csv"
-        ),
-        optimal_capacity=(
-            f"{network_statistics_dir}/optimal_capacity.csv"
-        ),
+        installed_capacity=(f"{network_statistics_dir}/installed_capacity.csv"),
+        optimal_capacity=(f"{network_statistics_dir}/optimal_capacity.csv"),
     log:
         f"{logs_dir}/build_network_statistics.log",
     params:
@@ -150,33 +129,19 @@ rule build_network_statistics:
 rule make_comparison:
     input:
         demand_network=f"{network_statistics_dir}/demand.csv",
-        installed_capacity_network=(
-            f"{network_statistics_dir}/installed_capacity.csv"
-        ),
-        optimal_capacity_network=(
-            f"{network_statistics_dir}/optimal_capacity.csv"
-        ),
-        network_geojson_network=(
-            f"{network_statistics_dir}/network_model.geojson"
-        ),
+        installed_capacity_network=(f"{network_statistics_dir}/installed_capacity.csv"),
+        optimal_capacity_network=(f"{network_statistics_dir}/optimal_capacity.csv"),
+        network_geojson_network=(f"{network_statistics_dir}/network_model.geojson"),
         demand_reference=f"{reference_statistics_dir}/demand.csv",
         installed_capacity_reference=(
             f"{reference_statistics_dir}/installed_capacity.csv"
         ),
-        network_geojson_reference=(
-            f"{reference_statistics_dir}/network_exist.geojson"
-        ),
+        network_geojson_reference=(f"{reference_statistics_dir}/network_exist.geojson"),
     output:
         demand_comparison=f"{results_dir}/tables/demand.csv",
-        installed_capacity_comparison=(
-            f"{results_dir}/tables/installed_capacity.csv"
-        ),
-        optimal_capacity_comparison=(
-            f"{results_dir}/tables/optimal_capacity.csv"
-        ),
-        network_comparison_geojson=(
-            f"{results_dir}/network_comparison.geojson"
-        ),
+        installed_capacity_comparison=(f"{results_dir}/tables/installed_capacity.csv"),
+        optimal_capacity_comparison=(f"{results_dir}/tables/optimal_capacity.csv"),
+        network_comparison_geojson=(f"{results_dir}/network_comparison.geojson"),
     log:
         f"{logs_dir}/make_comparison.log",
     script:
@@ -186,12 +151,8 @@ rule make_comparison:
 rule visualize_data:
     input:
         demand_comparison=f"{results_dir}/tables/demand.csv",
-        installed_capacity_comparison=(
-            f"{results_dir}/tables/installed_capacity.csv"
-        ),
-        optimal_capacity_comparison=(
-            f"{results_dir}/tables/optimal_capacity.csv"
-        ),
+        installed_capacity_comparison=(f"{results_dir}/tables/installed_capacity.csv"),
+        optimal_capacity_comparison=(f"{results_dir}/tables/optimal_capacity.csv"),
         osm_lines=os.path.join(
             config["plot_osm_grid_network"]["grid_path"],
             "all_clean_lines.geojson",
@@ -201,37 +162,20 @@ rule visualize_data:
             "all_clean_substations.geojson",
         ),
     output:
-        plot_demand=(
-            f"{results_dir}/figures/demand_comparison.png"
-        ),
+        plot_demand=(f"{results_dir}/figures/demand_comparison.png"),
         plot_installed_capacity=(
-            f"{results_dir}/figures/"
-            "installed_capacity_comparison.png"
+            f"{results_dir}/figures/" "installed_capacity_comparison.png"
         ),
-        plot_capacity_mix=(
-            f"{results_dir}/figures/capacity_mix_comparison.png"
-        ),
-        plot_capacity_grid=(
-            f"{results_dir}/figures/capacity_grid_comparison.png"
-        ),
-        plot_grid_network=(
-            f"{results_dir}/figures/grid_network.png"
-        ),
-        line_length_by_voltage=(
-            f"{results_dir}/tables/line_length_by_voltage.csv"
-        ),
+        plot_capacity_mix=(f"{results_dir}/figures/capacity_mix_comparison.png"),
+        plot_capacity_grid=(f"{results_dir}/figures/capacity_grid_comparison.png"),
+        plot_grid_network=(f"{results_dir}/figures/grid_network.png"),
+        line_length_by_voltage=(f"{results_dir}/tables/line_length_by_voltage.csv"),
     log:
         f"{logs_dir}/visualize_data.log",
     params:
-        line_voltages=config[
-            "plot_osm_grid_network"
-        ]["line_voltages"],
-        voltage_colors=config[
-            "plot_osm_grid_network"
-        ]["voltage_colors"],
-        plot_circuits=config[
-            "plot_osm_grid_network"
-        ]["plot_circuits"],
+        line_voltages=config["plot_osm_grid_network"]["line_voltages"],
+        voltage_colors=config["plot_osm_grid_network"]["voltage_colors"],
+        plot_circuits=config["plot_osm_grid_network"]["plot_circuits"],
     script:
         "scripts/visualize_data.py"
 

--- a/Snakefile
+++ b/Snakefile
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
+import os
 import sys
 
 sys.path.append("./scripts")
@@ -21,13 +22,18 @@ network_path = validation_config["network_path"]
 countries = validation_config["countries"]
 years = validation_config["year"]
 
-validation_id = validation_config["name"]
+validation_name = validation_config["name"]
 
+reference_statistics_dir = "resources/reference_statistics"
+network_statistics_dir = "resources/network_statistics"
+results_dir = "results"
+logs_dir = "logs"
 
-reference_statistics_dir = f"resources/reference_statistics/{validation_id}"
-network_statistics_dir = f"resources/network_statistics/{validation_id}"
-results_dir = f"results/{validation_id}"
-logs_dir = f"logs/{validation_id}"
+if validation_name:
+    reference_statistics_dir += f"/{validation_name}"
+    network_statistics_dir += f"/{validation_name}"
+    results_dir += f"/{validation_name}"
+    logs_dir += f"/{validation_name}"
 
 
 rule clean:

--- a/Snakefile
+++ b/Snakefile
@@ -63,8 +63,8 @@ rule build_reference_installed_capacity_irena:
 rule build_network_geojson:
     input:
         buscodes="data/electricity_transmission/Input - Center points.csv",
-        lineexist=("data/electricity_transmission/" "GTD-v1.1_regional_existing.csv"),
-        lineplan=("data/electricity_transmission/" "GTD-v1.1_regional_planned.csv"),
+        lineexist="data/electricity_transmission/GTD-v1.1_regional_existing.csv",
+        lineplan="data/electricity_transmission/GTD-v1.1_regional_planned.csv",
         network_path=network_path,
     output:
         network_existing=(f"{reference_statistics_dir}/network_exist.geojson"),

--- a/config.yaml
+++ b/config.yaml
@@ -14,6 +14,7 @@ datasets:
   # network: []  # list of datasets sources to validate networks. Not yet supported
 
 network_validation:
+  name: "validation_name" # Unique identifier for the validation run. Change it to keep outputs from different validation configurations separate.
   network_path: "resources/example_DE.nc" # File to the PyPSA network file to validate
   year: [2021]  # year of the network to validate
   countries: ['DE', 'FR']  # country of the network to validate

--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -22,6 +22,8 @@ SPDX-License-Identifier: CC-BY-4.0
 
 ### Minor Changes and bug-fixing
 
+* [Make validation outputs configuration-specific to avoid stale results when switching validation settings PR #62](https://github.com/pypsa-meets-earth/pypsa-earth-status/pull/62)
+
 * [Link year and country parameters to `build_reference_statistics` rule PR #58](https://github.com/pypsa-meets-earth/pypsa-earth-status/pull/58)
 
 * [Add Read the Docs badge to README.md PR #35](https://github.com/pypsa-meets-earth/pypsa-earth-status/pull/35)


### PR DESCRIPTION
## Closes #54 

## Changes proposed in this Pull Request

This PR makes validation outputs configuration-specific by deriving the output directories from the validation settings.

Previously, all validation runs shared the same output locations. As a result, changing the validation configuration (e.g. country, year, or network file) could lead to outputs from a previous run being reused, producing inconsistent comparisons or workflow errors due to missing data.

The workflow now generates a unique validation identifier based on the selected countries, reference year(s), and network file, and stores all generated artifacts in configuration-specific directories.

With this update, for instance, changing the validation country/year/network file automatically creates a new set of outputs and multiple validation configurations can coexist without overwriting each other.

## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented, including updates to docstrings for meaningful functions.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in all of `config.yaml`.
- [x] A note for the release notes `doc/release-notes.md` is amended in the format of previous release notes, including reference to the requested PR.
