### PR TITLE
Include validation for sector networks

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -10,7 +10,9 @@ SPDX-License-Identifier: CC-BY-4.0
 
 ### New Features and Major Changes
 
-* [Add electricity generation validation based on IRENA data PR #63](https://github.com/SPSUnipi/pypsa2smspp/pull/63)
+* [Design validation for electricity sector in sector networks PR #70](https://github.com/pypsa-meets-earth/pypsa-earth-status/pull/70)
+*
+* [Add electricity generation validation based on IRENA data PR #63](https://github.com/pypsa-meets-earth/pypsa-earth-status/pull/63)
 
 * [Add optional custom subfolder to resources and results folders PR #62](https://github.com/SPSUnipi/pypsa2smspp/pull/62)
 

--- a/scripts/build_network_statistics.py
+++ b/scripts/build_network_statistics.py
@@ -14,11 +14,22 @@ import pandas as pd
 import pypsa
 from helpers import configure_logging, harmonize_carrier_names, to_csv_nafix
 
-ELECTRICITY_BUS_CARRIERS = {"ac", "low voltage"}
+ELECTRICITY_BUS_CARRIERS = {
+    "ac",
+    "low voltage",
+    "dc",
+}
 # CO2_BUS_CARRIERS = {"co2", "co2 atmosphere"}
 NON_GENERATION_LINK_CARRIERS = {
     "battery discharger",
     "home battery discharger",
+    "b2b",
+}
+NON_GENERATION_GENERATOR_CARRIERS = {
+    "load shedding",
+}
+NON_GENERATION_STORAGE_UNIT_CARRIERS = {
+    "phs",
 }
 
 
@@ -79,7 +90,21 @@ def harmonize_electricity_carrier_names(carriers):
 
     result.loc[is_chp & normalized.str.contains("gas", regex=False)] = "gas"
 
+    # Project-specific comparison convention; this is not a direct mapping to the
+    # IRENA "Other renewable energy" category.
+    is_hydrogen_generation = normalized.str.contains(
+        r"\bh2\b",
+        regex=True,
+        na=False,
+    )
+    result.loc[is_hydrogen_generation] = "non-bio renewable fuels"
+
     result = harmonize_carrier_names(result)
+
+    # Keep waste separate from biomass because reference statistics provide a
+    # dedicated waste category.
+    is_waste = normalized.str.contains("waste", regex=False, na=False)
+    result.loc[is_waste] = "waste"
 
     # Apply this after general harmonization to prevent rooftop PV from being
     # merged with utility-scale PV.
@@ -131,12 +156,34 @@ def process_network_statistics(inputs, outputs):
     # Extract electricity demand
     electricity_buses = get_electricity_buses(network)
 
+    generator_carriers = (
+        network.generators["carrier"].fillna("").astype(str).str.strip().str.casefold()
+    )
+
+    # Exclude artificial generators from both capacity and generation statistics.
     electricity_generators = network.generators.index[
         network.generators["bus"].isin(electricity_buses)
+        & ~generator_carriers.isin(NON_GENERATION_GENERATOR_CARRIERS)
     ]
+
+    storage_unit_carriers = (
+        network.storage_units["carrier"]
+        .fillna("")
+        .astype(str)
+        .str.strip()
+        .str.casefold()
+    )
 
     electricity_storage_units = network.storage_units.index[
         network.storage_units["bus"].isin(electricity_buses)
+    ]
+
+    # Pumped storage is excluded from generation because it is not primary
+    # electricity generation.
+    generation_storage_units = electricity_storage_units[
+        ~storage_unit_carriers.loc[electricity_storage_units].isin(
+            NON_GENERATION_STORAGE_UNIT_CARRIERS
+        )
     ]
 
     electricity_loads = network.loads.index[
@@ -278,7 +325,7 @@ def process_network_statistics(inputs, outputs):
     storage_generation = (
         network.storage_units_t.p.reindex(
             index=network.snapshots,
-            columns=electricity_storage_units,
+            columns=generation_storage_units,
             fill_value=0.0,
         )
         .clip(lower=0.0)

--- a/scripts/build_network_statistics.py
+++ b/scripts/build_network_statistics.py
@@ -104,15 +104,14 @@ def process_network_statistics(inputs, outputs):
         network.loads["bus"].isin(electricity_buses)
     ]
 
-    demand = (
-        network.loads_t.p_set.reindex(
-            index=network.snapshots,
-            columns=electricity_loads,
-            fill_value=0.0,
-        ).mean()
-        * 8760
-        * 1e-6
+    load_p_set = network.get_switchable_as_dense("Load", "p_set").reindex(
+        index=network.snapshots,
+        columns=electricity_loads,
     )
+
+    weights = network.snapshot_weightings.generators.reindex(network.snapshots)
+
+    demand = load_p_set.mul(weights, axis=0).sum(axis=0).mul(1e-6)
 
     demand = demand.rename("demand").to_frame()
 

--- a/scripts/build_network_statistics.py
+++ b/scripts/build_network_statistics.py
@@ -15,7 +15,11 @@ import pypsa
 from helpers import configure_logging, harmonize_carrier_names, to_csv_nafix
 
 ELECTRICITY_BUS_CARRIERS = {"ac", "low voltage"}
-CO2_BUS_CARRIERS = {"co2", "co2 atmosphere"}
+# CO2_BUS_CARRIERS = {"co2", "co2 atmosphere"}
+NON_GENERATION_LINK_CARRIERS = {
+    "battery discharger",
+    "home battery discharger",
+}
 
 
 def get_electricity_buses(network):
@@ -26,53 +30,88 @@ def get_electricity_buses(network):
 
 def get_electricity_production_links(network):
     """
-    Return links representing electricity generation in the sector-coupled network.
+    Return links converting a non-electric energy carrier into electricity.
 
-    Conventional generators converted by PyPSA-Earth `scripts: prepare_sector_network.py` use:
-    bus0: fuel
-    bus1: electricity
-    bus2 or later: CO2
+    Links whose input and output buses both carry electricity are excluded
+    because they represent transmission, conversion, or distribution rather
+    than primary electricity generation.
 
-    CHP links also produce electricity on bus1. CHP without an explicit CO2
-    port is identified from its carrier.
+    Storage dischargers are excluded because their output is previously stored
+    electricity and should not be counted as primary generation.
     """
     if network.links.empty:
         return network.links.index[:0]
 
     electricity_buses = get_electricity_buses(network)
+
+    bus0_is_electric = network.links["bus0"].isin(electricity_buses)
     bus1_is_electric = network.links["bus1"].isin(electricity_buses)
 
-    has_co2_output = pd.Series(False, index=network.links.index)
-
-    for column in network.links.columns:
-        if not re.fullmatch(r"bus(?:[2-9]|[1-9][0-9]+)", column):
-            continue
-
-        output_bus_carriers = (
-            network.links[column]
-            .map(network.buses.carrier)
-            .fillna("")
-            .str.strip()
-            .str.lower()
-        )
-        has_co2_output |= output_bus_carriers.isin(CO2_BUS_CARRIERS)
-
-    is_chp = network.links.carrier.fillna("").str.contains(
-        r"\bCHP\b", case=False, regex=True
+    normalized_carriers = (
+        network.links["carrier"].fillna("").astype(str).str.strip().str.casefold()
     )
 
-    return network.links.index[bus1_is_electric & (has_co2_output | is_chp)]
+    is_storage_discharge = normalized_carriers.isin(NON_GENERATION_LINK_CARRIERS)
+
+    return network.links.index[
+        bus1_is_electric & ~bus0_is_electric & ~is_storage_discharge
+    ]
+
+
+def harmonize_electricity_carrier_names(carriers):
+    """
+    Harmonize electricity-producing technologies while keeping rooftop and
+    utility-scale solar as separate categories.
+    """
+    original = carriers.fillna("").astype(str)
+    normalized = original.str.strip().str.casefold()
+
+    result = original.copy()
+
+    is_biomass = normalized.str.contains("biomass", regex=False)
+    result.loc[is_biomass] = "biomass"
+
+    is_chp = normalized.str.contains("chp", regex=False)
+
+    result.loc[is_chp & normalized.str.contains("coal", regex=False)] = "coal"
+
+    result.loc[is_chp & normalized.str.contains("oil", regex=False)] = "oil"
+
+    result.loc[is_chp & normalized.str.contains("gas", regex=False)] = "gas"
+
+    result = harmonize_carrier_names(result)
+
+    # Apply this after general harmonization to prevent rooftop PV from being
+    # merged with utility-scale PV.
+    is_rooftop_solar = normalized.str.contains(
+        "solar", regex=False
+    ) & normalized.str.contains("rooftop", regex=False)
+    result.loc[is_rooftop_solar] = "solar rooftop"
+
+    return result
 
 
 def get_link_capacity(network, capacity_column):
-    """Return electrical output capacity of generation links."""
+    """Return electrical output capacity of electricity-producing links."""
+    production_links = get_electricity_production_links(network)
+
     links = network.links.loc[
-        get_electricity_production_links(network),
+        production_links,
         ["carrier", capacity_column, "efficiency", "bus1"],
     ].copy()
 
     if links.empty:
         return pd.DataFrame(columns=["carrier", "p_nom", "bus"])
+
+    links[capacity_column] = pd.to_numeric(
+        links[capacity_column],
+        errors="coerce",
+    ).fillna(0.0)
+
+    links["efficiency"] = pd.to_numeric(
+        links["efficiency"],
+        errors="coerce",
+    ).fillna(1.0)
 
     links["p_nom"] = links[capacity_column] * links["efficiency"]
 
@@ -149,7 +188,7 @@ def process_network_statistics(inputs, outputs):
         network.buses["country"]
     )
 
-    installed_capacity["carrier"] = harmonize_carrier_names(
+    installed_capacity["carrier"] = harmonize_electricity_carrier_names(
         installed_capacity["carrier"]
     )
 
@@ -197,7 +236,9 @@ def process_network_statistics(inputs, outputs):
 
     optimal_capacity["region"] = optimal_capacity["bus"].map(network.buses["country"])
 
-    optimal_capacity["carrier"] = harmonize_carrier_names(optimal_capacity["carrier"])
+    optimal_capacity["carrier"] = harmonize_electricity_carrier_names(
+        optimal_capacity["carrier"]
+    )
 
     optimal_capacity = optimal_capacity.groupby(["region", "carrier"])[["p_nom"]].sum()
 
@@ -303,15 +344,14 @@ def process_network_statistics(inputs, outputs):
     # Convert weighted MWh to GWh
     generation["generation"] /= 1e3
 
-    generation["region"] = network.buses.loc[
-        generation["bus"],
-        "country",
-    ].to_numpy()
+    generation["region"] = generation["bus"].map(network.buses["country"])
 
-    generation["carrier"] = harmonize_carrier_names(generation["carrier"])
+    generation["carrier"] = harmonize_electricity_carrier_names(generation["carrier"])
 
-    generation = generation.reset_index(drop=True).groupby(["region", "carrier"]).sum()
-    generation.drop(columns="bus", inplace=True)
+    generation = generation.groupby(
+        ["region", "carrier"],
+        as_index=True,
+    )[["generation"]].sum()
 
     to_csv_nafix(
         generation,

--- a/scripts/build_network_statistics.py
+++ b/scripts/build_network_statistics.py
@@ -14,6 +14,74 @@ import pandas as pd
 import pypsa
 from helpers import configure_logging, harmonize_carrier_names, to_csv_nafix
 
+ELECTRICITY_BUS_CARRIERS = {"ac", "low voltage"}
+CO2_BUS_CARRIERS = {"co2", "co2 atmosphere"}
+
+
+def get_electricity_buses(network):
+    """Return buses carrying electricity."""
+    bus_carriers = network.buses.carrier.fillna("").str.strip().str.lower()
+    return network.buses.index[bus_carriers.isin(ELECTRICITY_BUS_CARRIERS)]
+
+
+def get_electricity_production_links(network):
+    """
+    Return links representing electricity generation in the sector-coupled network.
+
+    Conventional generators converted by PyPSA-Earth `scripts: prepare_sector_network.py` use:
+    bus0: fuel
+    bus1: electricity
+    bus2 or later: CO2
+
+    CHP links also produce electricity on bus1. CHP without an explicit CO2
+    port is identified from its carrier.
+    """
+    if network.links.empty:
+        return network.links.index[:0]
+
+    electricity_buses = get_electricity_buses(network)
+    bus1_is_electric = network.links["bus1"].isin(electricity_buses)
+
+    has_co2_output = pd.Series(False, index=network.links.index)
+
+    for column in network.links.columns:
+        if not re.fullmatch(r"bus(?:[2-9]|[1-9][0-9]+)", column):
+            continue
+
+        output_bus_carriers = (
+            network.links[column]
+            .map(network.buses.carrier)
+            .fillna("")
+            .str.strip()
+            .str.lower()
+        )
+        has_co2_output |= output_bus_carriers.isin(CO2_BUS_CARRIERS)
+
+    is_chp = network.links.carrier.fillna("").str.contains(
+        r"\bCHP\b", case=False, regex=True
+    )
+
+    return network.links.index[bus1_is_electric & (has_co2_output | is_chp)]
+
+
+def get_link_capacity(network, capacity_column):
+    """Return electrical output capacity of generation links."""
+    links = network.links.loc[
+        get_electricity_production_links(network),
+        ["carrier", capacity_column, "efficiency", "bus1"],
+    ].copy()
+
+    if links.empty:
+        return pd.DataFrame(columns=["carrier", "p_nom", "bus"])
+
+    links["p_nom"] = links[capacity_column] * links["efficiency"]
+
+    return (
+        links[["carrier", "p_nom", "bus1"]]
+        .rename(columns={"bus1": "bus"})
+        .reset_index(drop=True)
+    )
+
 
 def process_network_statistics(inputs, outputs):
     """
@@ -21,30 +89,59 @@ def process_network_statistics(inputs, outputs):
     """
     network = pypsa.Network(inputs["network_path"])
 
-    # Extract demand
-    demand = network.loads_t.p_set.mean().T * 8760 * 1e-6
-    demand = demand.reset_index()
-    demand.columns = ["bus", "demand"]
-    demand = demand.set_index("bus")
-    demand["region"] = network.buses.loc[
-        network.loads.loc[demand.index, "bus"], "country"
+    # Extract electricity demand
+    electricity_buses = get_electricity_buses(network)
+
+    electricity_generators = network.generators.index[
+        network.generators["bus"].isin(electricity_buses)
     ]
-    demand = demand.groupby(["region"]).sum()
+
+    electricity_storage_units = network.storage_units.index[
+        network.storage_units["bus"].isin(electricity_buses)
+    ]
+
+    electricity_loads = network.loads.index[
+        network.loads["bus"].isin(electricity_buses)
+    ]
+
+    demand = (
+        network.loads_t.p_set.reindex(
+            index=network.snapshots,
+            columns=electricity_loads,
+            fill_value=0.0,
+        ).mean()
+        * 8760
+        * 1e-6
+    )
+
+    demand = demand.rename("demand").to_frame()
+
+    demand["region"] = (
+        network.loads.loc[demand.index, "bus"].map(network.buses["country"]).to_numpy()
+    )
+
+    demand = demand.groupby("region")[["demand"]].sum()
+
     to_csv_nafix(demand, outputs["demand"])
 
     # Extract installed capacity
-    generator_capacity = network.generators[["carrier", "p_nom", "bus"]].reset_index(
-        drop=True
-    )
+    generator_capacity = network.generators.loc[
+        electricity_generators,
+        ["carrier", "p_nom", "bus"],
+    ].reset_index(drop=True)
 
-    storage_capacity = network.storage_units[["carrier", "p_nom", "bus"]].reset_index(
-        drop=True
-    )
+    storage_capacity = network.storage_units.loc[
+        electricity_storage_units,
+        ["carrier", "p_nom", "bus"],
+    ].reset_index(drop=True)
+
+    link_capacity = get_link_capacity(network, "p_nom")
 
     installed_capacity = pd.concat(
         [
             generator_capacity,
             storage_capacity,
+            link_capacity,
         ],
         ignore_index=True,
     )
@@ -68,21 +165,33 @@ def process_network_statistics(inputs, outputs):
 
     # Extract optimal capacity from generators and storage units
     generator_optimal_capacity = (
-        network.generators[["carrier", "p_nom_opt", "bus"]]
+        network.generators.loc[
+            electricity_generators,
+            ["carrier", "p_nom_opt", "bus"],
+        ]
         .rename(columns={"p_nom_opt": "p_nom"})
         .reset_index(drop=True)
     )
 
     storage_optimal_capacity = (
-        network.storage_units[["carrier", "p_nom_opt", "bus"]]
+        network.storage_units.loc[
+            electricity_storage_units,
+            ["carrier", "p_nom_opt", "bus"],
+        ]
         .rename(columns={"p_nom_opt": "p_nom"})
         .reset_index(drop=True)
+    )
+
+    link_optimal_capacity = get_link_capacity(
+        network,
+        "p_nom_opt",
     )
 
     optimal_capacity = pd.concat(
         [
             generator_optimal_capacity,
             storage_optimal_capacity,
+            link_optimal_capacity,
         ],
         ignore_index=True,
     )
@@ -102,7 +211,7 @@ def process_network_statistics(inputs, outputs):
     generator_generation = (
         network.generators_t.p.reindex(
             index=network.snapshots,
-            columns=network.generators.index,
+            columns=electricity_generators,
             fill_value=0.0,
         )
         .clip(lower=0.0)
@@ -129,7 +238,7 @@ def process_network_statistics(inputs, outputs):
     storage_generation = (
         network.storage_units_t.p.reindex(
             index=network.snapshots,
-            columns=network.storage_units.index,
+            columns=electricity_storage_units,
             fill_value=0.0,
         )
         .clip(lower=0.0)
@@ -152,10 +261,42 @@ def process_network_statistics(inputs, outputs):
         "bus",
     ].to_numpy()
 
+    # Extract annual electricity generation from production links
+    production_links = get_electricity_production_links(network)
+
+    link_generation = (
+        (
+            -network.links_t.p1.reindex(
+                index=network.snapshots,
+                columns=production_links,
+                fill_value=0.0,
+            )
+        )
+        .clip(lower=0.0)
+        .mul(
+            network.snapshot_weightings.generators.reindex(network.snapshots),
+            axis=0,
+        )
+        .sum(axis=0)
+        .rename("generation")
+        .to_frame()
+    )
+
+    link_generation["carrier"] = network.links.loc[
+        link_generation.index,
+        "carrier",
+    ].to_numpy()
+
+    link_generation["bus"] = network.links.loc[
+        link_generation.index,
+        "bus1",
+    ].to_numpy()
+
     generation = pd.concat(
         [
             generator_generation,
             storage_generation,
+            link_generation,
         ],
         ignore_index=True,
     )

--- a/scripts/helpers.py
+++ b/scripts/helpers.py
@@ -33,9 +33,10 @@ IRENA_TECHNOLOGY_MAPPING = {
     "Biogas": "biomass",
     "Renewable municipal waste": "waste",
     "Geothermal energy": "geothermal",
+    "Non-bio renewable fuels": "non-bio renewable fuels",
     "Coal and peat": "coal",
     "Oil": "oil",
-    "Natural gas": "CCGT",
+    "Natural gas": "gas",
     "Fossil fuels n.e.s.": "oil",
     "Nuclear": "nuclear",
     "Other non-renewable energy": "other",
@@ -397,19 +398,27 @@ def create_country_list(input, iso_coding=True):
 
 
 def harmonize_carrier_names(series):
-    return series.str.lower().replace(
-        {
-            "solar": "pv",
-            "wind": "onwind",
-            "offwind": "offwind",
-            "ror": "hydro",
-            "run of river": "hydro",
-            "storage hydro": "hydro",
-            "phs": "hydro",
-            "wind onshore": "onshore",
-            "wind offshore": "offwind",
-            "offwind-dc": "offwind",
-            "offwind-ac": "offwind",
-            "hard coal": "coal",
-        }
+    return (
+        series.fillna("")
+        .astype(str)
+        .str.strip()
+        .str.casefold()
+        .replace(
+            {
+                "solar": "pv",
+                "wind": "onwind",
+                "offwind": "offwind",
+                "ror": "hydro",
+                "run of river": "hydro",
+                "storage hydro": "hydro",
+                "phs": "hydro",
+                "wind onshore": "onshore",
+                "wind offshore": "offwind",
+                "offwind-dc": "offwind",
+                "offwind-ac": "offwind",
+                "hard coal": "coal",
+                "ccgt": "gas",
+                "ocgt": "gas",
+            }
+        )
     )

--- a/scripts/make_comparison.py
+++ b/scripts/make_comparison.py
@@ -80,47 +80,51 @@ def compare_generation_statistics(
 ):
     """
     Compare annual electricity generation by region and carrier.
+
+    Keep technologies that occur in only one dataset. Missing values remain
+    NaN in the comparison data and are replaced by zero only when plotting.
     """
-    comparison_results = []
+    reference = (
+        reference_df.groupby(
+            ["region", "carrier"],
+            as_index=False,
+        )["generation"]
+        .sum()
+        .rename(
+            columns={
+                "generation": "reference_generation",
+            }
+        )
+    )
 
-    unique_combinations = reference_df[
+    network = (
+        network_df.groupby(
+            ["region", "carrier"],
+            as_index=False,
+        )["generation"]
+        .sum()
+        .rename(
+            columns={
+                "generation": "network_generation",
+            }
+        )
+    )
+
+    comparison_df = pd.merge(
+        reference,
+        network,
+        how="outer",
+        on=["region", "carrier"],
+    )
+
+    comparison_df = comparison_df[
         [
-            "region",
-            "carrier",
-        ]
-    ].drop_duplicates()
-
-    for _, row in unique_combinations.iterrows():
-        region = row["region"]
-        carrier = row["carrier"]
-
-        reference_row = reference_df[
-            (reference_df["region"] == region) & (reference_df["carrier"] == carrier)
-        ]
-
-        network_row = network_df[
-            (network_df["region"] == region) & (network_df["carrier"] == carrier)
-        ]
-
-        if not reference_row.empty and not network_row.empty:
-            comparison_results.append(
-                {
-                    "region": region,
-                    "carrier": carrier,
-                    "network_generation": (network_row["generation"].iloc[0]),
-                    "reference_generation": (reference_row["generation"].iloc[0]),
-                }
-            )
-
-    comparison_df = pd.DataFrame(
-        comparison_results,
-        columns=[
             "region",
             "carrier",
             "network_generation",
             "reference_generation",
-        ],
-    )
+        ]
+    ]
 
     return comparison_df.set_index("region")
 

--- a/scripts/visualize_data.py
+++ b/scripts/visualize_data.py
@@ -531,7 +531,13 @@ def plot_generation_comparison(
             .sort_index()
         )
 
-        region_df.fillna(0).plot(
+        plot_df = region_df.fillna(0).rename(
+            index={
+                "non-bio renewable fuels": "non-bio renewable\nfuels",
+            }
+        )
+
+        plot_df.plot(
             kind="bar",
             stacked=False,
             ax=ax,


### PR DESCRIPTION
## Changes proposed in this Pull Request

This PR extends validation of electricity generation, capacity and demand to support sector-coupled networks (especially considering the conversion of conventional generators to links). Those links are identified from their bus connections, while the existing behaviour for electricity-only networks is preserved.

## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented, including updates to docstrings for meaningful functions.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in all of `config.yaml`.
- [x] A note for the release notes `doc/release-notes.md` is amended in the format of previous release notes, including reference to the requested PR.
